### PR TITLE
新增使用远程配置

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM alpine:latest
 
+RUN apk add --no-cache curl
+
 WORKDIR /app
 
 COPY --from=builder /app/saveany-bot .
+COPY entrypoint.sh .
 
-ENTRYPOINT  ["/app/saveany-bot"]
+RUN chmod +x /app/saveany-bot && \
+    chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -n "$CONFIG_URL" ]; then
+    echo "[INFO] Downloading config from $CONFIG_URL"
+    if curl -sSLo /app/config.toml "$CONFIG_URL"; then
+        echo "[INFO] Configuration downloaded successfully"
+    else
+        echo "[ERROR] Failed to download config from $CONFIG_URL"
+        exit 1
+    fi
+fi
+
+if [ ! -f /app/config.toml ]; then
+    echo "[ERROR] Missing config.toml: 请通过挂载或 CONFIG_URL 提供配置文件"
+    exit 1
+fi
+    
+exec /app/saveany-bot


### PR DESCRIPTION
新增环境变量CONFIG_URL，用于使用远程配置文件，便于部署在PAAS平台上
```CONFIG_URL=https://gist.xx.com/xx/config.toml```
PS:未提供变量的情况下默认使用本地挂载文件