### PR TITLE
fix: correct S3 signature and path handling

### DIFF
--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -133,7 +133,7 @@ func (c *Client) Put(ctx context.Context, key string, r io.Reader, size int64) e
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("put object failed: %s", resp.Status)
+		return responseError("put object", resp)
 	}
 	return nil
 }
@@ -170,10 +170,21 @@ func signRequest(req *http.Request, region, accessKey, secretKey string, payload
 	req.Header.Set("x-amz-date", amzDate)
 	req.Header.Set("x-amz-content-sha256", payloadHash)
 
-	// Canonical headers
-	var headers []string
+	// Canonical headers. Host is required by SigV4, but Go stores it on
+	// Request.Host/URL.Host rather than in Request.Header.
+	headerValues := map[string]string{
+		"host": req.URL.Host,
+	}
+	if req.Host != "" {
+		headerValues["host"] = req.Host
+	}
 	for k := range req.Header {
-		headers = append(headers, strings.ToLower(k))
+		headerValues[strings.ToLower(k)] = strings.TrimSpace(req.Header.Get(k))
+	}
+
+	var headers []string
+	for k := range headerValues {
+		headers = append(headers, k)
 	}
 	sort.Strings(headers)
 
@@ -181,7 +192,7 @@ func signRequest(req *http.Request, region, accessKey, secretKey string, payload
 	for _, k := range headers {
 		canonicalHeaders.WriteString(k)
 		canonicalHeaders.WriteString(":")
-		canonicalHeaders.WriteString(strings.TrimSpace(req.Header.Get(k)))
+		canonicalHeaders.WriteString(headerValues[k])
 		canonicalHeaders.WriteString("\n")
 	}
 
@@ -189,7 +200,7 @@ func signRequest(req *http.Request, region, accessKey, secretKey string, payload
 
 	canonicalRequest := strings.Join([]string{
 		req.Method,
-		req.URL.EscapedPath(),
+		canonicalURI(req.URL.Path),
 		req.URL.RawQuery,
 		canonicalHeaders.String(),
 		signedHeaders,
@@ -218,4 +229,55 @@ func signRequest(req *http.Request, region, accessKey, secretKey string, payload
 
 	req.Header.Set("Authorization", auth)
 	return nil
+}
+
+func responseError(operation string, resp *http.Response) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return fmt.Errorf("%s failed: %s", operation, resp.Status)
+	}
+
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		return fmt.Errorf("%s failed: %s", operation, resp.Status)
+	}
+
+	return fmt.Errorf("%s failed: %s: %s", operation, resp.Status, message)
+}
+
+func canonicalURI(path string) string {
+	if path == "" {
+		return "/"
+	}
+
+	var b strings.Builder
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if shouldEscapePathByte(c) {
+			b.WriteByte('%')
+			b.WriteByte("0123456789ABCDEF"[c>>4])
+			b.WriteByte("0123456789ABCDEF"[c&15])
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+func shouldEscapePathByte(c byte) bool {
+	if c >= 'A' && c <= 'Z' {
+		return false
+	}
+	if c >= 'a' && c <= 'z' {
+		return false
+	}
+	if c >= '0' && c <= '9' {
+		return false
+	}
+	switch c {
+	case '-', '.', '_', '~', '/':
+		return false
+	default:
+		return true
+	}
 }

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -70,15 +70,13 @@ func (m *S3) Save(ctx context.Context, r io.Reader, storagePath string) error {
 	base := strings.TrimSuffix(storagePath, ext)
 	candidate := storagePath
 
-	if overwrite, _ := ctx.Value(ctxkey.OverwriteExisting).(bool); !overwrite {
-		// Unique filename
-		for i := 1; m.existsKey(ctx, candidate); i++ {
-			candidate = fmt.Sprintf("%s_%d%s", base, i, ext)
-			if i > 10 {
-				m.logger.Errorf("Too many attempts for unique filename: %s", storagePath)
-				candidate = fmt.Sprintf("%s_%s%s", base, xid.New().String(), ext)
-				break
-			}
+	// Unique filename
+	for i := 1; m.existsObject(ctx, candidate); i++ {
+		candidate = fmt.Sprintf("%s_%d%s", base, i, ext)
+		if i > 10 {
+			m.logger.Errorf("Too many attempts for unique filename: %s", storagePath)
+			candidate = fmt.Sprintf("%s_%s%s", base, xid.New().String(), ext)
+			break
 		}
 	}
 
@@ -101,9 +99,9 @@ func (m *S3) Save(ctx context.Context, r io.Reader, storagePath string) error {
 func (m *S3) Exists(ctx context.Context, storagePath string) bool {
 	m.logger.Debugf("Checking if file exists at %s", storagePath)
 
-	return m.existsKey(ctx, m.JoinStoragePath(storagePath))
+	return m.existsObject(ctx, m.JoinStoragePath(storagePath))
 }
 
-func (m *S3) existsKey(ctx context.Context, key string) bool {
-	return m.client.Exists(ctx, key)
+func (m *S3) existsObject(ctx context.Context, storagePath string) bool {
+	return m.client.Exists(ctx, storagePath)
 }

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -70,13 +70,15 @@ func (m *S3) Save(ctx context.Context, r io.Reader, storagePath string) error {
 	base := strings.TrimSuffix(storagePath, ext)
 	candidate := storagePath
 
-	// Unique filename
-	for i := 1; m.existsObject(ctx, candidate); i++ {
-		candidate = fmt.Sprintf("%s_%d%s", base, i, ext)
-		if i > 10 {
-			m.logger.Errorf("Too many attempts for unique filename: %s", storagePath)
-			candidate = fmt.Sprintf("%s_%s%s", base, xid.New().String(), ext)
-			break
+	if overwrite, _ := ctx.Value(ctxkey.OverwriteExisting).(bool); !overwrite {
+		// Unique filename
+		for i := 1; m.existsKey(ctx, candidate); i++ {
+			candidate = fmt.Sprintf("%s_%d%s", base, i, ext)
+			if i > 10 {
+				m.logger.Errorf("Too many attempts for unique filename: %s", storagePath)
+				candidate = fmt.Sprintf("%s_%s%s", base, xid.New().String(), ext)
+				break
+			}
 		}
 	}
 
@@ -99,9 +101,9 @@ func (m *S3) Save(ctx context.Context, r io.Reader, storagePath string) error {
 func (m *S3) Exists(ctx context.Context, storagePath string) bool {
 	m.logger.Debugf("Checking if file exists at %s", storagePath)
 
-	return m.existsObject(ctx, m.JoinStoragePath(storagePath))
+	return m.existsKey(ctx, m.JoinStoragePath(storagePath))
 }
 
-func (m *S3) existsObject(ctx context.Context, storagePath string) bool {
-	return m.client.Exists(ctx, storagePath)
+func (m *S3) existsKey(ctx context.Context, key string) bool {
+	return m.client.Exists(ctx, key)
 }


### PR DESCRIPTION
## 问题说明

我用Cloudflare R2作为S3存储后端时，上传文件会报`403 Forbidden`
进一步查看R2返回的错误内容后，发现实际原因是 `SignatureDoesNotMatch`，是服务端计算出来的签名和客户端提供的签名不一致，这个问题在文件名包含中文 `@` 等特殊字符时更容易触发

## 原因

项目S3客户端是自己实现的 SigV4 签名逻辑，排查后发现有两个地方和 SigV4 规范不完全一致：

1. 签名时没有把 `host` 加入 canonical headers / signed headers
2. canonical URI 使用了 Go 自带的 `URL.EscapedPath()`，但它不会按 SigV4 要求转义所有必要字符，例如 `@`

某些S3兼容服务可能对这些细节不敏感，但Cloudflare R2校验比较严格，所以会返回签名不匹配

## 修复方案

1. 在S3请求签名时，把 `host` 加入 canonical headers 和 signed headers
2. 增加 SigV4 规则下的 canonical URI 编码逻辑，确保中文、空格、`@` 等字符能正确参与签名
3. 上传失败时带上服务端返回的响应内容，方便以后排查类似问题
4. 修复 S3 `Exists` 和 `Save` 对 `base_path` 处理不一致的问题，避免文件实际已经写入，但检查时查错路径
