### PR TITLE
fix(api): sync task lifecycle state and restore GET /api/v1/tasks

### DIFF
--- a/api/factory.go
+++ b/api/factory.go
@@ -79,7 +79,9 @@ func (f *TaskFactory) createDirectLinksTask(taskID string, createdAt time.Time, 
 
 	task := directlinks.NewTask(taskID, f.ctx, params.URLs, stor, req.Path, nil)
 
-	if err := core.AddTask(f.ctx, task); err != nil {
+	RegisterTask(taskID, string(tasktype.TaskTypeDirectlinks), req.Storage, req.Path, task.Title(), req.Webhook)
+
+	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
 		return nil, fmt.Errorf("failed to add task: %w", err)
 	}
 
@@ -104,7 +106,9 @@ func (f *TaskFactory) createYTDLPTask(taskID string, createdAt time.Time, req *C
 
 	task := ytdlp.NewTask(taskID, f.ctx, params.URLs, params.Flags, stor, req.Path, nil)
 
-	if err := core.AddTask(f.ctx, task); err != nil {
+	RegisterTask(taskID, string(tasktype.TaskTypeYtdlp), req.Storage, req.Path, task.Title(), req.Webhook)
+
+	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
 		return nil, fmt.Errorf("failed to add task: %w", err)
 	}
 
@@ -146,7 +150,9 @@ func (f *TaskFactory) createAria2Task(taskID string, createdAt time.Time, req *C
 
 	task := aria2dl.NewTask(taskID, f.ctx, gid, params.URLs, aria2Client, stor, req.Path, nil)
 
-	if err := core.AddTask(f.ctx, task); err != nil {
+	RegisterTask(taskID, string(tasktype.TaskTypeAria2), req.Storage, req.Path, task.Title(), req.Webhook)
+
+	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
 		return nil, fmt.Errorf("failed to add task: %w", err)
 	}
 
@@ -190,7 +196,9 @@ func (f *TaskFactory) createParsedTask(taskID string, createdAt time.Time, req *
 
 	task := parsed.NewTask(taskID, f.ctx, stor, req.Path, item, nil)
 
-	if err := core.AddTask(f.ctx, task); err != nil {
+	RegisterTask(taskID, string(tasktype.TaskTypeParseditem), req.Storage, req.Path, task.Title(), req.Webhook)
+
+	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
 		return nil, fmt.Errorf("failed to add task: %w", err)
 	}
 
@@ -229,7 +237,8 @@ func (f *TaskFactory) createTGFilesTask(taskID string, createdAt time.Time, req 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tfile task: %w", err)
 		}
-		if err := core.AddTask(f.ctx, tfileTask); err != nil {
+		RegisterTask(taskID, string(tasktype.TaskTypeTgfiles), req.Storage, req.Path, tfileTask.Title(), req.Webhook)
+		if err := core.AddTask(f.ctx, NewExecutableWrapper(tfileTask)); err != nil {
 			return nil, fmt.Errorf("failed to add task: %w", err)
 		}
 	} else {
@@ -244,7 +253,8 @@ func (f *TaskFactory) createTGFilesTask(taskID string, createdAt time.Time, req 
 		}
 
 		task := batchtfile.NewBatchTGFileTask(taskID, f.ctx, elems, nil, true)
-		if err := core.AddTask(f.ctx, task); err != nil {
+		RegisterTask(taskID, string(tasktype.TaskTypeTgfiles), req.Storage, req.Path, task.Title(), req.Webhook)
+		if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
 			return nil, fmt.Errorf("failed to add task: %w", err)
 		}
 	}
@@ -281,7 +291,9 @@ func (f *TaskFactory) createTPHPicsTask(taskID string, createdAt time.Time, req 
 	client := telegraph.NewClient()
 	task := tphtask.NewTask(taskID, f.ctx, phPath, pics, stor, req.Path, client, nil)
 
-	if err := core.AddTask(f.ctx, task); err != nil {
+	RegisterTask(taskID, string(tasktype.TaskTypeTphpics), req.Storage, req.Path, task.Title(), req.Webhook)
+
+	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
 		return nil, fmt.Errorf("failed to add task: %w", err)
 	}
 
@@ -342,7 +354,9 @@ func (f *TaskFactory) createTransferTask(taskID string, createdAt time.Time, req
 
 	task := transfer.NewTransferTask(taskID, f.ctx, elems, nil, true)
 
-	if err := core.AddTask(f.ctx, task); err != nil {
+	RegisterTask(taskID, string(tasktype.TaskTypeTransfer), params.TargetStorage, params.TargetPath, task.Title(), req.Webhook)
+
+	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
 		return nil, fmt.Errorf("failed to add task: %w", err)
 	}
 

--- a/api/factory.go
+++ b/api/factory.go
@@ -66,6 +66,19 @@ func (f *TaskFactory) CreateTask(req *CreateTaskRequest) (*CreateTaskResponse, e
 	}
 }
 
+func (f *TaskFactory) registerAndEnqueueTask(task core.Executable, taskType tasktype.TaskType, storageName, path, webhook string) error {
+	taskID := task.TaskID()
+	RegisterTask(taskID, string(taskType), storageName, path, task.Title(), webhook)
+
+	err := core.AddTask(f.ctx, NewExecutableWrapper(task))
+	if err != nil {
+		DeleteTask(taskID)
+		return fmt.Errorf("failed to add task: %w", err)
+	}
+
+	return nil
+}
+
 // createDirectLinksTask 创建直链下载任务
 func (f *TaskFactory) createDirectLinksTask(taskID string, createdAt time.Time, req *CreateTaskRequest, stor storage.Storage) (*CreateTaskResponse, error) {
 	var params DirectLinksParams
@@ -79,10 +92,9 @@ func (f *TaskFactory) createDirectLinksTask(taskID string, createdAt time.Time, 
 
 	task := directlinks.NewTask(taskID, f.ctx, params.URLs, stor, req.Path, nil)
 
-	RegisterTask(taskID, string(tasktype.TaskTypeDirectlinks), req.Storage, req.Path, task.Title(), req.Webhook)
-
-	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
-		return nil, fmt.Errorf("failed to add task: %w", err)
+	err := f.registerAndEnqueueTask(task, tasktype.TaskTypeDirectlinks, req.Storage, req.Path, req.Webhook)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CreateTaskResponse{
@@ -106,10 +118,9 @@ func (f *TaskFactory) createYTDLPTask(taskID string, createdAt time.Time, req *C
 
 	task := ytdlp.NewTask(taskID, f.ctx, params.URLs, params.Flags, stor, req.Path, nil)
 
-	RegisterTask(taskID, string(tasktype.TaskTypeYtdlp), req.Storage, req.Path, task.Title(), req.Webhook)
-
-	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
-		return nil, fmt.Errorf("failed to add task: %w", err)
+	err := f.registerAndEnqueueTask(task, tasktype.TaskTypeYtdlp, req.Storage, req.Path, req.Webhook)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CreateTaskResponse{
@@ -150,10 +161,9 @@ func (f *TaskFactory) createAria2Task(taskID string, createdAt time.Time, req *C
 
 	task := aria2dl.NewTask(taskID, f.ctx, gid, params.URLs, aria2Client, stor, req.Path, nil)
 
-	RegisterTask(taskID, string(tasktype.TaskTypeAria2), req.Storage, req.Path, task.Title(), req.Webhook)
-
-	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
-		return nil, fmt.Errorf("failed to add task: %w", err)
+	err = f.registerAndEnqueueTask(task, tasktype.TaskTypeAria2, req.Storage, req.Path, req.Webhook)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CreateTaskResponse{
@@ -196,10 +206,9 @@ func (f *TaskFactory) createParsedTask(taskID string, createdAt time.Time, req *
 
 	task := parsed.NewTask(taskID, f.ctx, stor, req.Path, item, nil)
 
-	RegisterTask(taskID, string(tasktype.TaskTypeParseditem), req.Storage, req.Path, task.Title(), req.Webhook)
-
-	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
-		return nil, fmt.Errorf("failed to add task: %w", err)
+	err = f.registerAndEnqueueTask(task, tasktype.TaskTypeParseditem, req.Storage, req.Path, req.Webhook)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CreateTaskResponse{
@@ -231,16 +240,15 @@ func (f *TaskFactory) createTGFilesTask(taskID string, createdAt time.Time, req 
 		return nil, fmt.Errorf("no files found in provided links")
 	}
 
+	var task core.Executable
+
 	if len(files) == 1 {
 		// 单个文件任务
 		tfileTask, err := tfile.NewTGFileTask(taskID, f.ctx, files[0], stor, req.Path, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tfile task: %w", err)
 		}
-		RegisterTask(taskID, string(tasktype.TaskTypeTgfiles), req.Storage, req.Path, tfileTask.Title(), req.Webhook)
-		if err := core.AddTask(f.ctx, NewExecutableWrapper(tfileTask)); err != nil {
-			return nil, fmt.Errorf("failed to add task: %w", err)
-		}
+		task = tfileTask
 	} else {
 		// 批量文件任务
 		elems := make([]batchtfile.TaskElement, 0, len(files))
@@ -252,11 +260,12 @@ func (f *TaskFactory) createTGFilesTask(taskID string, createdAt time.Time, req 
 			elems = append(elems, *elem)
 		}
 
-		task := batchtfile.NewBatchTGFileTask(taskID, f.ctx, elems, nil, true)
-		RegisterTask(taskID, string(tasktype.TaskTypeTgfiles), req.Storage, req.Path, task.Title(), req.Webhook)
-		if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
-			return nil, fmt.Errorf("failed to add task: %w", err)
-		}
+		task = batchtfile.NewBatchTGFileTask(taskID, f.ctx, elems, nil, true)
+	}
+
+	err = f.registerAndEnqueueTask(task, tasktype.TaskTypeTgfiles, req.Storage, req.Path, req.Webhook)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CreateTaskResponse{
@@ -291,10 +300,9 @@ func (f *TaskFactory) createTPHPicsTask(taskID string, createdAt time.Time, req 
 	client := telegraph.NewClient()
 	task := tphtask.NewTask(taskID, f.ctx, phPath, pics, stor, req.Path, client, nil)
 
-	RegisterTask(taskID, string(tasktype.TaskTypeTphpics), req.Storage, req.Path, task.Title(), req.Webhook)
-
-	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
-		return nil, fmt.Errorf("failed to add task: %w", err)
+	err = f.registerAndEnqueueTask(task, tasktype.TaskTypeTphpics, req.Storage, req.Path, req.Webhook)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CreateTaskResponse{
@@ -354,10 +362,9 @@ func (f *TaskFactory) createTransferTask(taskID string, createdAt time.Time, req
 
 	task := transfer.NewTransferTask(taskID, f.ctx, elems, nil, true)
 
-	RegisterTask(taskID, string(tasktype.TaskTypeTransfer), params.TargetStorage, params.TargetPath, task.Title(), req.Webhook)
-
-	if err := core.AddTask(f.ctx, NewExecutableWrapper(task)); err != nil {
-		return nil, fmt.Errorf("failed to add task: %w", err)
+	err = f.registerAndEnqueueTask(task, tasktype.TaskTypeTransfer, params.TargetStorage, params.TargetPath, req.Webhook)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CreateTaskResponse{

--- a/api/server.go
+++ b/api/server.go
@@ -30,16 +30,21 @@ func NewServer(ctx context.Context) *Server {
 	mux.HandleFunc("/health", handlers.HealthCheckHandler)
 
 	// API v1 路由
-	mux.HandleFunc("/api/v1/tasks", handlers.CreateTaskHandler)
+	mux.HandleFunc("/api/v1/tasks", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handlers.ListTasksHandler(w, r)
+		case http.MethodPost:
+			handlers.CreateTaskHandler(w, r)
+		default:
+			MethodNotAllowedHandler(w, r)
+		}
+	})
 	mux.HandleFunc("/api/v1/tasks/", func(w http.ResponseWriter, r *http.Request) {
 		// 根据方法和路径分发
 		switch r.Method {
 		case http.MethodGet:
-			if r.URL.Path == "/api/v1/tasks" {
-				handlers.ListTasksHandler(w, r)
-			} else {
-				handlers.GetTaskHandler(w, r)
-			}
+			handlers.GetTaskHandler(w, r)
 		case http.MethodDelete:
 			handlers.CancelTaskHandler(w, r)
 		default:

--- a/api/wrapper.go
+++ b/api/wrapper.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/krau/SaveAny-Bot/core"
+	"github.com/krau/SaveAny-Bot/pkg/enums/tasktype"
+)
+
+// ExecutableWrapper wraps core.Executable to track task status in the API store and send webhooks.
+type ExecutableWrapper struct {
+	inner core.Executable
+}
+
+func NewExecutableWrapper(inner core.Executable) *ExecutableWrapper {
+	return &ExecutableWrapper{inner: inner}
+}
+
+func (w *ExecutableWrapper) Type() tasktype.TaskType { return w.inner.Type() }
+func (w *ExecutableWrapper) Title() string           { return w.inner.Title() }
+func (w *ExecutableWrapper) TaskID() string          { return w.inner.TaskID() }
+
+func (w *ExecutableWrapper) Execute(ctx context.Context) error {
+	taskID := w.inner.TaskID()
+
+	if info, ok := GetTask(taskID); ok {
+		info.UpdateStatus(TaskStatusRunning)
+	}
+
+	err := w.inner.Execute(ctx)
+
+	info, ok := GetTask(taskID)
+	if !ok {
+		return err
+	}
+
+	var status TaskStatus
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			status = TaskStatusCancelled
+			info.UpdateStatus(TaskStatusCancelled)
+		} else {
+			status = TaskStatusFailed
+			info.SetError(err.Error())
+		}
+	} else {
+		status = TaskStatusCompleted
+		info.UpdateStatus(TaskStatusCompleted)
+	}
+
+	if info.Webhook != "" {
+		payload := CreateWebhookPayload(taskID, info.Type, status, info.Storage, info.Path, err)
+		SendWebhook(ctx, payload)
+	}
+
+	return err
+}


### PR DESCRIPTION
## Summary

This PR fixes inconsistencies in the task API by:

- registering API-created tasks before they enter the worker queue
- tracking task lifecycle state during execution
- persisting failure details for failed tasks
- sending webhooks based on the final execution result
- restoring correct routing for `GET /api/v1/tasks`

- Fixes #215

## Problem

The API had two related issues:

1. Tasks created through the API were executed by the core queue, but their API-visible lifecycle state was not updated consistently.
2. The `/api/v1/tasks` route did not correctly support `GET` for listing tasks.

As a result, API consumers could create tasks, but could not reliably observe execution progress or final outcomes through the API.

## Before

- API-created tasks could be queued and executed without consistent status transitions.
- Task status might remain at its initial state instead of moving to `running`, `completed`, `failed`, or `cancelled`.
- Failed tasks did not reliably expose error details.
- Webhook notifications were not reliably tied to the final task result.
- `GET /api/v1/tasks` was not properly handled on the canonical collection endpoint.

## After

- Each API-created task is registered in the API task store before enqueueing.
- Queued tasks are wrapped so API state is updated throughout execution.
- Task status now transitions correctly:
  - `running` when execution starts
  - `completed` when execution succeeds
  - `failed` when execution returns an error
  - `cancelled` when execution is interrupted by context cancellation
- Failed tasks now retain error details for API consumers.
- Webhooks are sent using the final task outcome.
- `/api/v1/tasks` now correctly supports:
  - `GET` to list tasks
  - `POST` to create tasks

## Impact

- API clients can now reliably monitor task progress and terminal states.
- Webhook consumers receive more consistent completion and failure events.
- The task collection endpoint behaves as expected for REST clients.
- This brings API-visible task state back in sync with actual queue execution.
