### PR TITLE
fix: remove cache files after reader closes

### DIFF
--- a/common/utils/fsutil/file_test.go
+++ b/common/utils/fsutil/file_test.go
@@ -1,0 +1,42 @@
+package fsutil_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krau/SaveAny-Bot/common/utils/fsutil"
+)
+
+func TestCloseAndRemove(t *testing.T) {
+	tests := []struct {
+		name     string
+		preClose bool
+	}{
+		{name: "open file"},
+		{name: "already closed file", preClose: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "cache-file")
+			file, err := fsutil.CreateFile(filePath)
+			if err != nil {
+				t.Fatalf("CreateFile() failed: %v", err)
+			}
+			if tt.preClose {
+				if err := file.Close(); err != nil {
+					t.Fatalf("Close() failed: %v", err)
+				}
+			}
+
+			if err := file.CloseAndRemove(); err != nil {
+				t.Fatalf("CloseAndRemove() failed: %v", err)
+			}
+			if _, err := os.Stat(filePath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("cache file still exists after CloseAndRemove(): %v", err)
+			}
+		})
+	}
+}

--- a/common/utils/fsutil/fs.go
+++ b/common/utils/fsutil/fs.go
@@ -1,6 +1,7 @@
 package fsutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,10 +42,11 @@ func (f *File) Remove() error {
 }
 
 func (f *File) CloseAndRemove() error {
-	if err := f.Close(); err != nil {
-		return err
+	closeErr := f.Close()
+	if errors.Is(closeErr, os.ErrClosed) {
+		closeErr = nil
 	}
-	return f.Remove()
+	return errors.Join(closeErr, f.Remove())
 }
 
 func CreateFile(fp string) (*File, error) {


### PR DESCRIPTION
## Summary

- continue removing temporary files when the reader was already closed by an upload client
- preserve other close and remove errors with errors.Join
- add regression coverage for both open and already-closed files

## Problem

HTTP clients may close request bodies after an upload. CloseAndRemove previously returned immediately when Close reported that the file was already closed, so Remove was never called and completed Telegraph uploads left every temporary image in the cache directory.

## Testing

- go test ./common/utils/fsutil
- go test -skip Test\(CreateSplitZip\|ExtractThumbFrame\|GetVideoMetadata\)$ ./...
- go test -run ^$ ./...
- go vet ./...
- live verification with a 103-image Telegraph task left no task cache files and emitted no cleanup errors